### PR TITLE
Enabling replacing the country list

### DIFF
--- a/src/CountryValidator.php
+++ b/src/CountryValidator.php
@@ -1,0 +1,65 @@
+<?php
+
+/*
+ * (c) Rob Bast <rob.bast@gmail.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace League\ISO3166;
+
+use InvalidArgumentException;
+
+class CountryValidator
+{
+    use ValidatorTrait;
+
+    /**
+     * new Instance
+     * @param mixed $countries an iterable object/structure where each item
+     *                         represents a valid country array data
+     */
+    public function validateMany(array $countries = [])
+    {
+        foreach ($countries as &$country) {
+            $country = $this->validateOne($country);
+        }
+        unset($country);
+
+        return $countries;
+    }
+
+    /**
+     * Validate and normalize a country array
+     *
+     * @param array $country
+     *
+     * @throws InvalidArgumentException if required indexes are missing
+     *
+     * @return array
+     */
+    public function validateOne(array $country)
+    {
+        if (!isset(
+            $country[ISO3166::KEY_ALPHA2],
+            $country[ISO3166::KEY_ALPHA3],
+            $country[ISO3166::KEY_NUMERIC],
+            $country['currency'],
+            $country['name']
+        )) {
+            throw new InvalidArgumentException(sprintf(
+                'Invalid value for $country, one of the following required key is missing: %s',
+                implode(', ', [ISO3166::KEY_ALPHA2, ISO3166::KEY_ALPHA3, ISO3166::KEY_NUMERIC, 'currency', 'name'])
+            ));
+        }
+
+        return [
+            ISO3166::KEY_ALPHA2 => $this->validateAlpha2($country[ISO3166::KEY_ALPHA2]),
+            ISO3166::KEY_ALPHA3 => $this->validateAlpha3($country[ISO3166::KEY_ALPHA3]),
+            ISO3166::KEY_NUMERIC => $this->validateNumeric($country[ISO3166::KEY_NUMERIC]),
+            'currency' => $this->validateCurrencies($country['currency']),
+            'name' => $this->validateName($country['name']),
+        ];
+    }
+}

--- a/src/ISO3166.php
+++ b/src/ISO3166.php
@@ -17,176 +17,22 @@ use OutOfBoundsException;
 
 class ISO3166 implements Countable, IteratorAggregate, DataProvider
 {
+    use ValidatorTrait;
+
     const KEY_ALPHA2 = 'alpha2';
     const KEY_ALPHA3 = 'alpha3';
     const KEY_NUMERIC = 'numeric';
 
     /**
      * new Instance
-     * @param mixed $countries an iterable object/structure where each item
+     * @param array $countries an iterable object/structure where each item
      *                         represents a valid country array data
      */
-    public function __construct($countries = [])
+    public function __construct(array $countries = [])
     {
-        if ($countries) {
-            $list = [];
-            foreach ($countries as $country) {
-                $list[] = $this->validateCountryArray($country);
-            }
-            $this->countries = $list;
+        if (!empty($countries)) {
+            $this->countries = $countries;
         }
-    }
-
-    /**
-     * Validate and normalize a country array
-     *
-     * @param array $country
-     *
-     * @throws InvalidArgumentException if required indexes are missing
-     * @throws DomainException if the input array does not conform to the expected format
-     *
-     * @return array
-     */
-    protected function validateCountryArray(array $country)
-    {
-        if (!isset(
-            $country[self::KEY_ALPHA2],
-            $country[self::KEY_ALPHA3],
-            $country[self::KEY_NUMERIC],
-            $country['currency'],
-            $country['name']
-        )) {
-            throw new InvalidArgumentException(sprintf(
-                'Invalid value for $country, one of the following required key is missing: %s',
-                implode(', ', [ISO3166::KEY_ALPHA2, ISO3166::KEY_ALPHA3, ISO3166::KEY_NUMERIC, 'currency'])
-            ));
-        }
-
-        return [
-            self::KEY_ALPHA2 => $this->validateAlpha2($country[self::KEY_ALPHA2]),
-            self::KEY_ALPHA3 => $this->validateAlpha3($country[self::KEY_ALPHA3]),
-            self::KEY_NUMERIC => $this->validateNumeric($country[self::KEY_NUMERIC]),
-            'currency' => $this->validateCurrencies($country['currency']),
-            'name' => $this->validateName($country['name']),
-        ];
-    }
-
-    /**
-     * Validate and normalized ISO3166-1-alpha2-code
-     *
-     * @param  string $input
-     *
-     * @throws DomainException if input does not conform to alpha2 format.
-     *
-     * @return string
-     */
-    protected function validateAlpha2($input)
-    {
-        if (!preg_match('/^[a-zA-Z]{2}$/', $input)) {
-            throw new DomainException('Not a valid alpha2: ' . $input);
-        }
-
-        return strtoupper($input);
-    }
-
-    /**
-     * Validate and normalized ISO3166-1-alpha3-code
-     *
-     * @param  string $input
-     *
-     * @throws DomainException if input does not conform to alpha3 format.
-     *
-     * @return string
-     */
-    protected function validateAlpha3($input)
-    {
-        if (!preg_match('/^[a-zA-Z]{3}$/', $input)) {
-            throw new DomainException('Not a valid alpha3: ' . $input);
-        }
-
-        return strtoupper($input);
-    }
-
-    /**
-     * Validate and normalized ISO3166-1-numeric-code
-     *
-     * @param  string $input
-     *
-     * @throws DomainException if input does not conform to numeric format.
-     *
-     * @return string
-     */
-    protected function validateNumeric($input)
-    {
-        if (!preg_match('/^[0-9]{3}$/', $input)) {
-            throw new DomainException('Not a valid numeric: ' . $input);
-        }
-
-        return $input;
-    }
-
-    /**
-     * Validate and normalized ISO4217-alpha3-code
-     *
-     * @param mixed $input a string or an iterable object
-     *
-     * @return string|array
-     */
-    protected function validateCurrencies($input)
-    {
-        if (is_array($input)) {
-            $list = [];
-            foreach ($input as $currency) {
-                $list[] = $this->validateCurrency($currency);
-            }
-            return $list;
-        }
-
-        return $this->validateCurrency($input);
-    }
-
-    /**
-     * Validate and normalized ISO4217-alpha3-code
-     *
-     * @param string $input a string or an iterable object
-     *
-     * @throws DomainException if input does not conform to ISO4217 alpha3 format.
-     *
-     * @return string
-     */
-    protected function validateCurrency($input)
-    {
-        if (!preg_match('/^[a-zA-Z]{3}$/', $input)) {
-            throw new DomainException('Not a valid ISO4217 currency code: ' . $input);
-        }
-
-        return strtoupper($input);
-    }
-
-    /**
-     * Validate and normalized the country name
-     *
-     * @param string $str a string or an iterable object
-     *
-     * @throws DomainException if input is empty
-     *
-     * @return string
-     */
-    protected function validateName($input)
-    {
-        if (is_string($input) || (is_object($input) && !method_exists($input, '__toString'))) {
-            $input = trim((string) $input);
-            if ('' !== $input) {
-                return $input;
-            }
-
-            throw new DomainException('A country name can not be empty');
-        }
-
-        throw new InvalidArgumentException(sprintf(
-            'Expected data to be a string; received "%s"',
-            (is_object($input) ? get_class($input) : gettype($input))
-        ));
     }
 
     /**
@@ -301,7 +147,7 @@ class ISO3166 implements Countable, IteratorAggregate, DataProvider
      */
     private function getBy($key, $value)
     {
-        foreach ($this as $country) {
+        foreach ($this->countries as $country) {
             if ($value === $country[$key]) {
                 return $country;
             }

--- a/src/ISO3166.php
+++ b/src/ISO3166.php
@@ -9,11 +9,185 @@
 
 namespace League\ISO3166;
 
-class ISO3166 implements \IteratorAggregate, DataProvider
+use Countable;
+use DomainException;
+use IteratorAggregate;
+use InvalidArgumentException;
+use OutOfBoundsException;
+
+class ISO3166 implements Countable, IteratorAggregate, DataProvider
 {
     const KEY_ALPHA2 = 'alpha2';
     const KEY_ALPHA3 = 'alpha3';
     const KEY_NUMERIC = 'numeric';
+
+    /**
+     * new Instance
+     * @param mixed $countries an iterable object/structure where each item
+     *                         represents a valid country array data
+     */
+    public function __construct($countries = [])
+    {
+        if ($countries) {
+            $list = [];
+            foreach ($countries as $country) {
+                $list[] = $this->validateCountryArray($country);
+            }
+            $this->countries = $list;
+        }
+    }
+
+    /**
+     * Validate and normalize a country array
+     *
+     * @param array $country
+     *
+     * @throws InvalidArgumentException if required indexes are missing
+     * @throws DomainException if the input array does not conform to the expected format
+     *
+     * @return array
+     */
+    protected function validateCountryArray(array $country)
+    {
+        if (!isset(
+            $country[self::KEY_ALPHA2],
+            $country[self::KEY_ALPHA3],
+            $country[self::KEY_NUMERIC],
+            $country['currency'],
+            $country['name']
+        )) {
+            throw new InvalidArgumentException(sprintf(
+                'Invalid value for $country, one of the following required key is missing: %s',
+                implode(', ', [ISO3166::KEY_ALPHA2, ISO3166::KEY_ALPHA3, ISO3166::KEY_NUMERIC, 'currency'])
+            ));
+        }
+
+        return [
+            self::KEY_ALPHA2 => $this->validateAlpha2($country[self::KEY_ALPHA2]),
+            self::KEY_ALPHA3 => $this->validateAlpha3($country[self::KEY_ALPHA3]),
+            self::KEY_NUMERIC => $this->validateNumeric($country[self::KEY_NUMERIC]),
+            'currency' => $this->validateCurrencies($country['currency']),
+            'name' => $this->validateName($country['name']),
+        ];
+    }
+
+    /**
+     * Validate and normalized ISO3166-1-alpha2-code
+     *
+     * @param  string $input
+     *
+     * @throws DomainException if input does not conform to alpha2 format.
+     *
+     * @return string
+     */
+    protected function validateAlpha2($input)
+    {
+        if (!preg_match('/^[a-zA-Z]{2}$/', $input)) {
+            throw new DomainException('Not a valid alpha2: ' . $input);
+        }
+
+        return strtoupper($input);
+    }
+
+    /**
+     * Validate and normalized ISO3166-1-alpha3-code
+     *
+     * @param  string $input
+     *
+     * @throws DomainException if input does not conform to alpha3 format.
+     *
+     * @return string
+     */
+    protected function validateAlpha3($input)
+    {
+        if (!preg_match('/^[a-zA-Z]{3}$/', $input)) {
+            throw new DomainException('Not a valid alpha3: ' . $input);
+        }
+
+        return strtoupper($input);
+    }
+
+    /**
+     * Validate and normalized ISO3166-1-numeric-code
+     *
+     * @param  string $input
+     *
+     * @throws DomainException if input does not conform to numeric format.
+     *
+     * @return string
+     */
+    protected function validateNumeric($input)
+    {
+        if (!preg_match('/^[0-9]{3}$/', $input)) {
+            throw new DomainException('Not a valid numeric: ' . $input);
+        }
+
+        return $input;
+    }
+
+    /**
+     * Validate and normalized ISO4217-alpha3-code
+     *
+     * @param mixed $input a string or an iterable object
+     *
+     * @return string|array
+     */
+    protected function validateCurrencies($input)
+    {
+        if (is_array($input)) {
+            $list = [];
+            foreach ($input as $currency) {
+                $list[] = $this->validateCurrency($currency);
+            }
+            return $list;
+        }
+
+        return $this->validateCurrency($input);
+    }
+
+    /**
+     * Validate and normalized ISO4217-alpha3-code
+     *
+     * @param string $input a string or an iterable object
+     *
+     * @throws DomainException if input does not conform to ISO4217 alpha3 format.
+     *
+     * @return string
+     */
+    protected function validateCurrency($input)
+    {
+        if (!preg_match('/^[a-zA-Z]{3}$/', $input)) {
+            throw new DomainException('Not a valid ISO4217 currency code: ' . $input);
+        }
+
+        return strtoupper($input);
+    }
+
+    /**
+     * Validate and normalized the country name
+     *
+     * @param string $str a string or an iterable object
+     *
+     * @throws DomainException if input is empty
+     *
+     * @return string
+     */
+    protected function validateName($input)
+    {
+        if (is_string($input) || (is_object($input) && !method_exists($input, '__toString'))) {
+            $input = trim((string) $input);
+            if ('' !== $input) {
+                return $input;
+            }
+
+            throw new DomainException('A country name can not be empty');
+        }
+
+        throw new InvalidArgumentException(sprintf(
+            'Expected data to be a string; received "%s"',
+            (is_object($input) ? get_class($input) : gettype($input))
+        ));
+    }
 
     /**
      * Lookup ISO3166-1 data by alpha2 identifier.
@@ -22,18 +196,11 @@ class ISO3166 implements \IteratorAggregate, DataProvider
      *
      * @param string $alpha2
      *
-     * @throws \DomainException if input does not conform to alpha2 format.
-     * @throws \OutOfBoundsException if input does not exist in ISO3166-1.
-     *
      * @return array
      */
     public function getByAlpha2($alpha2)
     {
-        if (!preg_match('/^[a-zA-Z]{2}$/', $alpha2)) {
-            throw new \DomainException('Not a valid alpha2: ' . $alpha2);
-        }
-
-        return $this->getBy(self::KEY_ALPHA2, $alpha2);
+        return $this->getBy(self::KEY_ALPHA2, $this->validateAlpha2($alpha2));
     }
 
     /**
@@ -43,18 +210,11 @@ class ISO3166 implements \IteratorAggregate, DataProvider
      *
      * @param string $alpha3
      *
-     * @throws \DomainException if input does not conform to alpha3 format.
-     * @throws \OutOfBoundsException if input does not exist in ISO3166-1.
-     *
      * @return array
      */
     public function getByAlpha3($alpha3)
     {
-        if (!preg_match('/^[a-zA-Z]{3}$/', $alpha3)) {
-            throw new \DomainException('Not a valid alpha3: ' . $alpha3);
-        }
-
-        return $this->getBy(self::KEY_ALPHA3, $alpha3);
+        return $this->getBy(self::KEY_ALPHA3,  $this->validateAlpha3($alpha3));
     }
 
     /**
@@ -64,18 +224,13 @@ class ISO3166 implements \IteratorAggregate, DataProvider
      *
      * @param string $numeric
      *
-     * @throws \DomainException if input does not conform to numeric format.
-     * @throws \OutOfBoundsException if input does not exist in ISO3166-1.
+     * @throws DomainException if input does not conform to numeric format.
      *
      * @return array
      */
     public function getByNumeric($numeric)
     {
-        if (!preg_match('/^[0-9]{3}$/', $numeric)) {
-            throw new \DomainException('Not a valid numeric: ' . $numeric);
-        }
-
-        return $this->getBy(self::KEY_NUMERIC, $numeric);
+        return $this->getBy(self::KEY_NUMERIC, $this->validateNumeric($numeric));
     }
 
     /**
@@ -86,28 +241,6 @@ class ISO3166 implements \IteratorAggregate, DataProvider
     public function getAll()
     {
         return $this->countries;
-    }
-
-    /**
-     * @api
-     *
-     * @param string $listBy
-     *
-     * @return \Generator
-     */
-    public function listBy($listBy = self::KEY_ALPHA2)
-    {
-        if (!in_array($listBy, $keys = [self::KEY_ALPHA2, self::KEY_ALPHA3, self::KEY_NUMERIC], true)) {
-            throw new \DomainException(sprintf(
-                'Invalid value for $indexBy, got "%s", expected one of: %s',
-                $listBy,
-                implode(', ', $keys)
-            ));
-        }
-
-        foreach ($this->countries as $country) {
-            yield $country[$listBy] => $country;
-        }
     }
 
     /**
@@ -123,6 +256,38 @@ class ISO3166 implements \IteratorAggregate, DataProvider
     }
 
     /**
+     * @internal
+     *
+     * @return int
+     */
+    public function count()
+    {
+        return count($this->countries);
+    }
+
+    /**
+     * @api
+     *
+     * @param string $listBy
+     *
+     * @return \Generator
+     */
+    public function listBy($listBy = self::KEY_ALPHA2)
+    {
+        if (!in_array($listBy, $keys = [self::KEY_ALPHA2, self::KEY_ALPHA3, self::KEY_NUMERIC], true)) {
+            throw new DomainException(sprintf(
+                'Invalid value for $indexBy, got "%s", expected one of: %s',
+                $listBy,
+                implode(', ', $keys)
+            ));
+        }
+
+        foreach ($this->countries as $country) {
+            yield $country[$listBy] => $country;
+        }
+    }
+
+    /**
      * Lookup ISO3166-1 data by given identifier.
      *
      * Looks for a match against all known identifying keys of each entry in the dataset.
@@ -130,19 +295,19 @@ class ISO3166 implements \IteratorAggregate, DataProvider
      * @param string $key
      * @param string $value
      *
-     * @throws \OutOfBoundsException
+     * @throws OutOfBoundsException
      *
      * @return array
      */
     private function getBy($key, $value)
     {
         foreach ($this as $country) {
-            if (0 === strcasecmp($value, $country[$key])) {
+            if ($value === $country[$key]) {
                 return $country;
             }
         }
 
-        throw new \OutOfBoundsException('ISO 3166-1 does not contain: ' . $value);
+        throw new OutOfBoundsException(sprintf('ISO 3166-1 does not contain: %s', $value));
     }
 
     /**
@@ -154,7 +319,7 @@ class ISO3166 implements \IteratorAggregate, DataProvider
      *
      * @param string $id
      *
-     * @throws \OutOfBoundsException
+     * @throws OutOfBoundsException
      *
      * @return array
      */
@@ -169,7 +334,7 @@ class ISO3166 implements \IteratorAggregate, DataProvider
             }
         }
 
-        throw new \OutOfBoundsException('ISO 3166-1 does not contain: ' . $id);
+        throw new OutOfBoundsException('ISO 3166-1 does not contain: ' . $id);
     }
 
     /**

--- a/src/ValidatorTrait.php
+++ b/src/ValidatorTrait.php
@@ -1,0 +1,135 @@
+<?php
+
+/*
+ * (c) Rob Bast <rob.bast@gmail.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace League\ISO3166;
+
+use DomainException;
+use InvalidArgumentException;
+use OutOfBoundsException;
+
+trait ValidatorTrait
+{
+    /**
+     * Validate and normalized ISO3166-1-alpha2-code
+     *
+     * @param  string $input
+     *
+     * @throws DomainException if input does not conform to alpha2 format.
+     *
+     * @return string
+     */
+    protected function validateAlpha2($input)
+    {
+        if (!preg_match('/^[a-zA-Z]{2}$/', $input)) {
+            throw new DomainException('Not a valid alpha2: ' . $input);
+        }
+
+        return strtoupper($input);
+    }
+
+    /**
+     * Validate and normalized ISO3166-1-alpha3-code
+     *
+     * @param  string $input
+     *
+     * @throws DomainException if input does not conform to alpha3 format.
+     *
+     * @return string
+     */
+    protected function validateAlpha3($input)
+    {
+        if (!preg_match('/^[a-zA-Z]{3}$/', $input)) {
+            throw new DomainException('Not a valid alpha3: ' . $input);
+        }
+
+        return strtoupper($input);
+    }
+
+    /**
+     * Validate and normalized ISO3166-1-numeric-code
+     *
+     * @param  string $input
+     *
+     * @throws DomainException if input does not conform to numeric format.
+     *
+     * @return string
+     */
+    protected function validateNumeric($input)
+    {
+        if (!preg_match('/^[0-9]{3}$/', $input)) {
+            throw new DomainException('Not a valid numeric: ' . $input);
+        }
+
+        return sprintf('%03d', $input);
+    }
+
+    /**
+     * Validate and normalized ISO4217-alpha3-code
+     *
+     * @param mixed $input a string or an iterable object
+     *
+     * @return string|array
+     */
+    protected function validateCurrencies($input)
+    {
+        if (is_array($input)) {
+            $list = [];
+            foreach ($input as $currency) {
+                $list[] = $this->validateCurrency($currency);
+            }
+            return $list;
+        }
+
+        return $this->validateCurrency($input);
+    }
+
+    /**
+     * Validate and normalized ISO4217-alpha3-code
+     *
+     * @param string $input a string or an iterable object
+     *
+     * @throws DomainException if input does not conform to ISO4217 alpha3 format.
+     *
+     * @return string
+     */
+    protected function validateCurrency($input)
+    {
+        if (!preg_match('/^[a-zA-Z]{3}$/', $input)) {
+            throw new DomainException('Not a valid ISO4217 currency code: ' . $input);
+        }
+
+        return strtoupper($input);
+    }
+
+    /**
+     * Validate and normalized the country name
+     *
+     * @param string $str a string or an iterable object
+     *
+     * @throws DomainException if input is empty
+     *
+     * @return string
+     */
+    protected function validateName($input)
+    {
+        if (is_string($input) || (is_object($input) && !method_exists($input, '__toString'))) {
+            $input = trim((string) $input);
+            if ('' !== $input) {
+                return $input;
+            }
+
+            throw new DomainException('A country name can not be empty');
+        }
+
+        throw new InvalidArgumentException(sprintf(
+            'Expected data to be a string; received "%s"',
+            (is_object($input) ? get_class($input) : gettype($input))
+        ));
+    }
+}

--- a/tests/CountryValidatorTest.php
+++ b/tests/CountryValidatorTest.php
@@ -1,0 +1,112 @@
+<?php
+
+/*
+ * (c) Rob Bast <rob.bast@gmail.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace League\ISO3166;
+
+use League\ISO3166\CountryValidator;
+
+class CountryValidatorTest extends \PHPUnit_Framework_TestCase
+{
+    protected $validator;
+
+    public function setup()
+    {
+        $this->validator = new CountryValidator();
+    }
+
+    public function teardown()
+    {
+        $this->validator = null;
+    }
+
+    public function testValidateManyNormalizeInput()
+    {
+        $arr = [
+            [
+                ISO3166::KEY_ALPHA2 => 'fo',
+                ISO3166::KEY_ALPHA3 => 'FoO',
+                ISO3166::KEY_NUMERIC => 111,
+                'currency' => ['bar'],
+                'name' => 'The country of Foo',
+            ],
+            [
+                ISO3166::KEY_ALPHA2 => 'BA',
+                ISO3166::KEY_ALPHA3 => 'Bar',
+                ISO3166::KEY_NUMERIC => 444,
+                'currency' => 'bAz',
+                'name' => '     The country of Bar      ',
+            ],
+        ];
+        $res = $this->validator->validateMany($arr);
+
+        $this->assertSame('FO', $res[0][ISO3166::KEY_ALPHA2]);
+        $this->assertSame('FOO', $res[0][ISO3166::KEY_ALPHA3]);
+        $this->assertSame('111', $res[0][ISO3166::KEY_NUMERIC]);
+        $this->assertSame('BAR', $res[1][ISO3166::KEY_ALPHA3]);
+        $this->assertSame('444', $res[1][ISO3166::KEY_NUMERIC]);
+        $this->assertSame('BAZ', $res[1]['currency']);
+        $this->assertSame('The country of Bar', $res[1]['name']);
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     */
+    public function testNewInstanceThrowsInvalidArgumentException()
+    {
+        $this->validator->validateMany([[]]);
+    }
+
+    /**
+     * @expectedException \DomainException
+     */
+    public function testNewInstanceThrowsDomainExceptionOnBadCurrency()
+    {
+        $arr = [
+            ISO3166::KEY_ALPHA2 => 'Ba',
+            ISO3166::KEY_ALPHA3 => 'BaR',
+            ISO3166::KEY_NUMERIC => 444,
+            'currency' => '444',
+            'name' => 'The country of BAR',
+        ];
+
+        $this->validator->validateOne($arr);
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     */
+    public function testNewInstanceThrowsInvalidArgumentExceptionOnBadName()
+    {
+        $arr = [
+            ISO3166::KEY_ALPHA2 => 'Ba',
+            ISO3166::KEY_ALPHA3 => 'BaR',
+            ISO3166::KEY_NUMERIC => 444,
+            'currency' => 'BAZ',
+            'name' => [],
+        ];
+
+        $this->validator->validateOne($arr);
+    }
+
+    /**
+     * @expectedException \DomainException
+     */
+    public function testNewInstanceThrowsDomainExceptionOnBadName()
+    {
+        $arr = [
+            ISO3166::KEY_ALPHA2 => 'BA',
+            ISO3166::KEY_ALPHA3 => 'BaR',
+            ISO3166::KEY_NUMERIC => 444,
+            'currency' => 'BAZ',
+            'name' => '',
+        ];
+
+        $this->validator->validateOne($arr);
+    }
+}

--- a/tests/ISO3166Test.php
+++ b/tests/ISO3166Test.php
@@ -11,7 +11,6 @@ namespace League\ISO3166;
 
 class ISO3166Test extends \PHPUnit_Framework_TestCase
 {
-
     /**
      * @testdox Calling the constructor with a user defined country list
      */
@@ -20,89 +19,25 @@ class ISO3166Test extends \PHPUnit_Framework_TestCase
         $arr = [
             [
                 ISO3166::KEY_ALPHA2 => 'FO',
-                ISO3166::KEY_ALPHA3 => 'FoO',
+                ISO3166::KEY_ALPHA3 => 'FOO',
                 ISO3166::KEY_NUMERIC => 111,
-                'currency' => ['bAr'],
+                'currency' => ['BAR'],
                 'name' => 'The country of Foo',
             ],
             [
                 ISO3166::KEY_ALPHA2 => 'BA',
-                ISO3166::KEY_ALPHA3 => 'BaR',
+                ISO3166::KEY_ALPHA3 => 'BAR',
                 ISO3166::KEY_NUMERIC => 444,
                 'currency' => 'BAZ',
-                'name' => '    The country of Bar     ',
+                'name' => 'The country of Bar',
             ],
         ];
         $collection = new ISO3166($arr);
+        $this->assertCount(2, $collection);
         $this->assertInternalType('array', $collection->getByAlpha3('FOO'));
-        $this->assertSame(['BAR'], $collection->getByAlpha2('Fo')['currency']);
+        $this->assertSame(['BAR'], $collection->getByAlpha2('FO')['currency']);
         $this->assertSame('BAZ', $collection->getByAlpha3('BAR')['currency']);
         $this->assertSame('The country of Bar', $collection->getByAlpha3('BAR')['name']);
-        $this->assertCount(2, $collection);
-    }
-
-    /**
-     * @testdox Calling the constructor with invalid country array throws a InvalidArgumentException
-     * @expectedException \InvalidArgumentException
-     */
-    public function testNewInstanceThrowsInvalidArgumentException()
-    {
-        new ISO3166([[]]);
-    }
-
-    /**
-     * @testdox Calling the constructor with a wrongly formatted user defined country list
-     * @expectedException \DomainException
-     * @expectedExceptionMessageRegExp /^Not a valid ISO4217 currency code: .*$/
-     */
-    public function testNewInstanceThrowsDomainExceptionOnBadCurrency()
-    {
-        $arr = [
-            [
-                ISO3166::KEY_ALPHA2 => 'BA',
-                ISO3166::KEY_ALPHA3 => 'BaR',
-                ISO3166::KEY_NUMERIC => 444,
-                'currency' => '444',
-                'name' => 'The country of BAR',
-            ],
-        ];
-        new ISO3166($arr);
-    }
-
-    /**
-     * @testdox Calling the constructor with a wrongly formatted user defined country list
-     * @expectedException \InvalidArgumentException
-     */
-    public function testNewInstanceThrowsInvalidArgumentExceptionOnBadName()
-    {
-        $arr = [
-            [
-                ISO3166::KEY_ALPHA2 => 'BA',
-                ISO3166::KEY_ALPHA3 => 'BaR',
-                ISO3166::KEY_NUMERIC => 444,
-                'currency' => 'BAZ',
-                'name' => [],
-            ],
-        ];
-        new ISO3166($arr);
-    }
-
-    /**
-     * @testdox Calling the constructor with a wrongly formatted user defined country list
-     * @expectedException \DomainException
-     */
-    public function testNewInstanceThrowsDomainExceptionOnBadName()
-    {
-        $arr = [
-            [
-                ISO3166::KEY_ALPHA2 => 'BA',
-                ISO3166::KEY_ALPHA3 => 'BaR',
-                ISO3166::KEY_NUMERIC => 444,
-                'currency' => 'BAZ',
-                'name' => '',
-            ],
-        ];
-        new ISO3166($arr);
     }
 
     /**

--- a/tests/ISO3166Test.php
+++ b/tests/ISO3166Test.php
@@ -11,6 +11,100 @@ namespace League\ISO3166;
 
 class ISO3166Test extends \PHPUnit_Framework_TestCase
 {
+
+    /**
+     * @testdox Calling the constructor with a user defined country list
+     */
+    public function testConstructor()
+    {
+        $arr = [
+            [
+                ISO3166::KEY_ALPHA2 => 'FO',
+                ISO3166::KEY_ALPHA3 => 'FoO',
+                ISO3166::KEY_NUMERIC => 111,
+                'currency' => ['bAr'],
+                'name' => 'The country of Foo',
+            ],
+            [
+                ISO3166::KEY_ALPHA2 => 'BA',
+                ISO3166::KEY_ALPHA3 => 'BaR',
+                ISO3166::KEY_NUMERIC => 444,
+                'currency' => 'BAZ',
+                'name' => '    The country of Bar     ',
+            ],
+        ];
+        $collection = new ISO3166($arr);
+        $this->assertInternalType('array', $collection->getByAlpha3('FOO'));
+        $this->assertSame(['BAR'], $collection->getByAlpha2('Fo')['currency']);
+        $this->assertSame('BAZ', $collection->getByAlpha3('BAR')['currency']);
+        $this->assertSame('The country of Bar', $collection->getByAlpha3('BAR')['name']);
+        $this->assertCount(2, $collection);
+    }
+
+    /**
+     * @testdox Calling the constructor with invalid country array throws a InvalidArgumentException
+     * @expectedException \InvalidArgumentException
+     */
+    public function testNewInstanceThrowsInvalidArgumentException()
+    {
+        new ISO3166([[]]);
+    }
+
+    /**
+     * @testdox Calling the constructor with a wrongly formatted user defined country list
+     * @expectedException \DomainException
+     * @expectedExceptionMessageRegExp /^Not a valid ISO4217 currency code: .*$/
+     */
+    public function testNewInstanceThrowsDomainExceptionOnBadCurrency()
+    {
+        $arr = [
+            [
+                ISO3166::KEY_ALPHA2 => 'BA',
+                ISO3166::KEY_ALPHA3 => 'BaR',
+                ISO3166::KEY_NUMERIC => 444,
+                'currency' => '444',
+                'name' => 'The country of BAR',
+            ],
+        ];
+        new ISO3166($arr);
+    }
+
+    /**
+     * @testdox Calling the constructor with a wrongly formatted user defined country list
+     * @expectedException \InvalidArgumentException
+     */
+    public function testNewInstanceThrowsInvalidArgumentExceptionOnBadName()
+    {
+        $arr = [
+            [
+                ISO3166::KEY_ALPHA2 => 'BA',
+                ISO3166::KEY_ALPHA3 => 'BaR',
+                ISO3166::KEY_NUMERIC => 444,
+                'currency' => 'BAZ',
+                'name' => [],
+            ],
+        ];
+        new ISO3166($arr);
+    }
+
+    /**
+     * @testdox Calling the constructor with a wrongly formatted user defined country list
+     * @expectedException \DomainException
+     */
+    public function testNewInstanceThrowsDomainExceptionOnBadName()
+    {
+        $arr = [
+            [
+                ISO3166::KEY_ALPHA2 => 'BA',
+                ISO3166::KEY_ALPHA3 => 'BaR',
+                ISO3166::KEY_NUMERIC => 444,
+                'currency' => 'BAZ',
+                'name' => '',
+            ],
+        ];
+        new ISO3166($arr);
+    }
+
     /**
      * @testdox Calling getByAlpha2 with an invalid alpha2 throws a DomainException.
      * @dataProvider invalidAlpha2Provider


### PR DESCRIPTION
- adding an optional $countries argument to the constructor
- adding the Countable Interface to determine the number of country in the collection
- adding country array validation and normalization
- adding more internal method to reuse validation and normalization everywhere in the class
- remove the use of strcasecmp since the data is normalized
- test suite is updated to take into account the new feature
