### PR TITLE
Fix: Require friendsofphp/php-cs-fixer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,7 @@
         }
     },
     "require-dev": {
+        "friendsofphp/php-cs-fixer": "2.0.0-alpha",
         "phpunit/phpunit": "^4.6 || ^5.0"
     },
     "autoload-dev": {

--- a/composer.json
+++ b/composer.json
@@ -33,5 +33,9 @@
         "branch-alias": {
             "dev-master": "1.x-dev"
         }
+    },
+    "scripts": {
+        "cs": "php-cs-fixer fix --verbose --diff",
+        "test": "phpunit"
     }
 }


### PR DESCRIPTION
This PR
- [x] requires `friendsofphp/php-cs-fixer`
- [x] adds composer script to ease local development

💁 If we have a [configuration](https://github.com/thephpleague/iso3166/blob/master/.php_cs), then we could just as well use it, right? 
