### PR TITLE
Fix: Generate coverage in an ignored directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+build/
 vendor/
 .php_cs.cache
 composer.lock

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -20,8 +20,8 @@
 
     <logging>
         <log type="coverage-text" target="php://stderr" />
-        <log type="coverage-html" target="coverage" showUncoveredFiles="true"/>
-        <log type="coverage-clover" target="coverage.xml" showUncoveredFiles="true"/>
+        <log type="coverage-html" target="build/coverage" showUncoveredFiles="true"/>
+        <log type="coverage-clover" target="build/coverage.xml" showUncoveredFiles="true"/>
     </logging>
 
 </phpunit>


### PR DESCRIPTION
This PR
- [x] generates coverage in a directory that has been added to `.gitignore`

💁 When checking out the repository and running

```
$ composer install && vendor/bin/phpunit
```

we end up with a dirty index.
