### PR TITLE
public visibility for getBy

### DIFF
--- a/src/ISO3166.php
+++ b/src/ISO3166.php
@@ -158,7 +158,7 @@ class ISO3166 implements \Countable, \IteratorAggregate, DataProvider
      *
      * @return array
      */
-    private function getBy($key, $value)
+    public function getBy($key, $value)
     {
         foreach ($this->countries as $country) {
             if (0 === strcasecmp($value, $country[$key])) {


### PR DESCRIPTION
I was looking for a lib that get a country code by country name and found this one. Unfortunately, it only works from a country code to a country name. I think it could be great to search by anything. That's why I changed the visibility. One other way may be to add a `getByName` method but I'm not sure it's better.
