### PR TITLE
several BC breaking api changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+* Changed: renamed `getBy<Identifier>` methods to `<identifier>` ([#29]).
+* Changed: renamed `getAll` to `all` ([#29]).
+* Changed: renamed `listBy` to `iterator` ([#29]).
 * Changed: `ISO3166` and `DataValidator` are now `final` ([#24]).
 * Changed: support for PHP 5.5.x has been dropped ([#23]).
 * Changed: `get()` method has been removed ([#19]).
@@ -27,6 +30,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 [1.0.1]: https://github.com/thephpleague/iso3166/compare/1.0.0...1.0.1
 [1.0.0]: https://github.com/thephpleague/iso3166/compare/64bae4f00dbd5679b9a36c54c37af73d5deb5be1...1.0.0
 
+[#29]: https://github.com/thephpleague/iso3166/issues/29
 [#24]: https://github.com/thephpleague/iso3166/issues/24
 [#23]: https://github.com/thephpleague/iso3166/issues/23
 [#19]: https://github.com/thephpleague/iso3166/issues/19

--- a/src/DataProvider.php
+++ b/src/DataProvider.php
@@ -16,19 +16,19 @@ interface DataProvider
      *
      * @param string $alpha2
      */
-    public function getByAlpha2($alpha2);
+    public function alpha2($alpha2);
 
     /**
      * Return data for given alpha3 code.
      *
      * @param string $alpha3
      */
-    public function getByAlpha3($alpha3);
+    public function alpha3($alpha3);
 
     /**
      * Return data for given numeric code.
      *
      * @param string $numeric
      */
-    public function getByNumeric($numeric);
+    public function numeric($numeric);
 }

--- a/src/ISO3166.php
+++ b/src/ISO3166.php
@@ -45,11 +45,11 @@ final class ISO3166 implements \Countable, \IteratorAggregate, DataProvider
      *
      * @return array
      */
-    public function getByAlpha2($alpha2)
+    public function alpha2($alpha2)
     {
         $this->guardAgainstInvalidAlpha2($alpha2);
 
-        return $this->getBy(self::KEY_ALPHA2, $alpha2);
+        return $this->lookup(self::KEY_ALPHA2, $alpha2);
     }
 
     /**
@@ -65,11 +65,11 @@ final class ISO3166 implements \Countable, \IteratorAggregate, DataProvider
      *
      * @return array
      */
-    public function getByAlpha3($alpha3)
+    public function alpha3($alpha3)
     {
         $this->guardAgainstInvalidAlpha3($alpha3);
 
-        return $this->getBy(self::KEY_ALPHA3, $alpha3);
+        return $this->lookup(self::KEY_ALPHA3, $alpha3);
     }
 
     /**
@@ -85,11 +85,11 @@ final class ISO3166 implements \Countable, \IteratorAggregate, DataProvider
      *
      * @return array
      */
-    public function getByNumeric($numeric)
+    public function numeric($numeric)
     {
         $this->guardAgainstInvalidNumeric($numeric);
 
-        return $this->getBy(self::KEY_NUMERIC, $numeric);
+        return $this->lookup(self::KEY_NUMERIC, $numeric);
     }
 
     /**
@@ -97,7 +97,7 @@ final class ISO3166 implements \Countable, \IteratorAggregate, DataProvider
      *
      * @return array
      */
-    public function getAll()
+    public function all()
     {
         return $this->countries;
     }
@@ -105,26 +105,28 @@ final class ISO3166 implements \Countable, \IteratorAggregate, DataProvider
     /**
      * @api
      *
-     * @param string $listBy
+     * @param string $key
      *
      * @return \Generator
      */
-    public function listBy($listBy = self::KEY_ALPHA2)
+    public function iterator($key = self::KEY_ALPHA2)
     {
-        if (!in_array($listBy, $keys = [self::KEY_ALPHA2, self::KEY_ALPHA3, self::KEY_NUMERIC], true)) {
+        if (!in_array($key, $keys = [self::KEY_ALPHA2, self::KEY_ALPHA3, self::KEY_NUMERIC], true)) {
             throw new \DomainException(sprintf(
                 'Invalid value for $indexBy, got "%s", expected one of: %s',
-                $listBy,
+                $key,
                 implode(', ', $keys)
             ));
         }
 
         foreach ($this->countries as $country) {
-            yield $country[$listBy] => $country;
+            yield $country[$key] => $country;
         }
     }
 
     /**
+     * @see \Countable.
+     *
      * @internal
      *
      * @return int
@@ -135,6 +137,8 @@ final class ISO3166 implements \Countable, \IteratorAggregate, DataProvider
     }
 
     /**
+     * @see \IteratorAggregate.
+     *
      * @internal
      *
      * @return \Generator
@@ -158,7 +162,7 @@ final class ISO3166 implements \Countable, \IteratorAggregate, DataProvider
      *
      * @return array
      */
-    private function getBy($key, $value)
+    private function lookup($key, $value)
     {
         foreach ($this->countries as $country) {
             if (0 === strcasecmp($value, $country[$key])) {

--- a/tests/ISO3166Test.php
+++ b/tests/ISO3166Test.php
@@ -44,7 +44,7 @@ class ISO3166Test extends \PHPUnit_Framework_TestCase
     {
         $this->setExpectedExceptionRegExp($expectedException, $exceptionPattern);
 
-        $this->iso3166->getByAlpha2($alpha2);
+        $this->iso3166->alpha2($alpha2);
     }
 
     /**
@@ -70,8 +70,8 @@ class ISO3166Test extends \PHPUnit_Framework_TestCase
      */
     public function testGetByAlpha2()
     {
-        $this->assertEquals($this->foo, $this->iso3166->getByAlpha2($this->foo[ISO3166::KEY_ALPHA2]));
-        $this->assertEquals($this->bar, $this->iso3166->getByAlpha2($this->bar[ISO3166::KEY_ALPHA2]));
+        $this->assertEquals($this->foo, $this->iso3166->alpha2($this->foo[ISO3166::KEY_ALPHA2]));
+        $this->assertEquals($this->bar, $this->iso3166->alpha2($this->bar[ISO3166::KEY_ALPHA2]));
     }
 
     /**
@@ -84,7 +84,7 @@ class ISO3166Test extends \PHPUnit_Framework_TestCase
     {
         $this->setExpectedExceptionRegExp($expectedException, $exceptionPattern);
 
-        $this->iso3166->getByAlpha3($alpha3);
+        $this->iso3166->alpha3($alpha3);
     }
 
     /**
@@ -110,8 +110,8 @@ class ISO3166Test extends \PHPUnit_Framework_TestCase
      */
     public function testGetByAlpha3()
     {
-        $this->assertEquals($this->foo, $this->iso3166->getByAlpha3($this->foo[ISO3166::KEY_ALPHA3]));
-        $this->assertEquals($this->bar, $this->iso3166->getByAlpha3($this->bar[ISO3166::KEY_ALPHA3]));
+        $this->assertEquals($this->foo, $this->iso3166->alpha3($this->foo[ISO3166::KEY_ALPHA3]));
+        $this->assertEquals($this->bar, $this->iso3166->alpha3($this->bar[ISO3166::KEY_ALPHA3]));
     }
 
     /**
@@ -124,7 +124,7 @@ class ISO3166Test extends \PHPUnit_Framework_TestCase
     {
         $this->setExpectedExceptionRegExp($expectedException, $exceptionPattern);
 
-        $this->iso3166->getByNumeric($numeric);
+        $this->iso3166->numeric($numeric);
     }
 
     /**
@@ -154,8 +154,8 @@ class ISO3166Test extends \PHPUnit_Framework_TestCase
      */
     public function testGetByNumeric()
     {
-        $this->assertEquals($this->foo, $this->iso3166->getByNumeric($this->foo[ISO3166::KEY_NUMERIC]));
-        $this->assertEquals($this->bar, $this->iso3166->getByNumeric($this->bar[ISO3166::KEY_NUMERIC]));
+        $this->assertEquals($this->foo, $this->iso3166->numeric($this->foo[ISO3166::KEY_NUMERIC]));
+        $this->assertEquals($this->bar, $this->iso3166->numeric($this->bar[ISO3166::KEY_NUMERIC]));
     }
 
     /**
@@ -163,7 +163,7 @@ class ISO3166Test extends \PHPUnit_Framework_TestCase
      */
     public function testGetAll()
     {
-        $this->assertInternalType('array', $this->iso3166->getAll(), 'getAll() should return an array.');
+        $this->assertInternalType('array', $this->iso3166->all(), 'getAll() should return an array.');
     }
 
     /**
@@ -176,7 +176,7 @@ class ISO3166Test extends \PHPUnit_Framework_TestCase
             ++$i;
         }
 
-        $this->assertEquals(count($this->iso3166->getAll()), $i, 'Compare iterated count to count(getAll()).');
+        $this->assertEquals(count($this->iso3166->all()), $i, 'Compare iterated count to count(getAll()).');
     }
 
     /**
@@ -185,7 +185,7 @@ class ISO3166Test extends \PHPUnit_Framework_TestCase
     public function testListBy()
     {
         try {
-            foreach ($this->iso3166->listBy('foo') as $key => $value) {
+            foreach ($this->iso3166->iterator('foo') as $key => $value) {
                 // void
             }
         } catch (\Exception $e) {
@@ -196,7 +196,7 @@ class ISO3166Test extends \PHPUnit_Framework_TestCase
         }
 
         $i = 0;
-        foreach ($this->iso3166->listBy(ISO3166::KEY_ALPHA3) as $key => $value) {
+        foreach ($this->iso3166->iterator(ISO3166::KEY_ALPHA3) as $key => $value) {
             ++$i;
         }
 


### PR DESCRIPTION
Since we're working towards a 2.x release, we can safely rename some api methods now, getting rid of some cruft that I personally have never been quite happy about.
