### PR TITLE
Add Country class

### DIFF
--- a/src/ISO3166.php
+++ b/src/ISO3166.php
@@ -9,7 +9,7 @@
 
 namespace League\ISO3166;
 
-final class ISO3166 implements \Countable, \IteratorAggregate, ISO3166DataProvider
+class ISO3166 implements \Countable, \IteratorAggregate, ISO3166DataProvider
 {
     use ISO3166KeyValidators;
 
@@ -121,7 +121,7 @@ final class ISO3166 implements \Countable, \IteratorAggregate, ISO3166DataProvid
      *
      * @return array
      */
-    private function lookup($key, $value)
+    protected function lookup($key, $value)
     {
         foreach ($this->countries as $country) {
             if (0 === strcasecmp($value, $country[$key])) {

--- a/src/Obj/Country.php
+++ b/src/Obj/Country.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace League\ISO3166\Obj;
+
+/**
+ * Value object for ISO3166 country information.
+ */
+class Country
+{
+    /** @var string */
+    public $name;
+
+    /** @var string */
+    public $alpha2;
+
+    /** @var string */
+    public $alpha3;
+
+    /** @var string */
+    public $numeric;
+
+    /** @var string[] */
+    public $currency;
+
+    /**
+     * @param string   $name
+     * @param string   $alpha2
+     * @param string   $alpha3
+     * @param string   $numeric
+     * @param string[] $currency
+     */
+    public function __construct(
+        $name,
+        $alpha2,
+        $alpha3,
+        $numeric,
+        array $currency
+    ) {
+        $this->name = $name;
+        $this->alpha2 = $alpha2;
+        $this->alpha3 = $alpha3;
+        $this->numeric = $numeric;
+        $this->currency = $currency;
+    }
+}

--- a/src/Obj/ISO3166.php
+++ b/src/Obj/ISO3166.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace League\ISO3166\Obj;
+
+/**
+ * OOP wrapper for the associative array based ISO3166.
+ *
+ * @method Country alpha2($alpha2)
+ * @method Country alpha3($alpha3)
+ * @method Country numeric($numeric)
+ */
+class ISO3166 extends \League\ISO3166\ISO3166
+{
+    /**
+     * @return Country[]
+     */
+    public function all()
+    {
+        return array_map(
+            function (array $assoc) {
+                return $this->makeCountry($assoc);
+            },
+            parent::all()
+        );
+    }
+
+    /**
+     * @param string $key
+     *
+     * @return \Generator
+     * @throws \DomainException
+     */
+    public function iterator($key = self::KEY_ALPHA2)
+    {
+        foreach (parent::iterator($key) as $index => $assoc) {
+            yield $index => $this->makeCountry($assoc);
+        }
+    }
+
+    /**
+     * @return \Generator|Country[]
+     */
+    public function getIterator()
+    {
+        foreach (parent::getIterator() as $country) {
+            yield $this->makeCountry($country);
+        }
+    }
+
+    /**
+     * @param string $key
+     * @param string $value
+     *
+     * @return Country
+     * @throws \OutOfBoundsException
+     */
+    protected function lookup($key, $value)
+    {
+        return $this->makeCountry(parent::lookup($key, $value));
+    }
+
+    /**
+     * @param array $assoc
+     *
+     * @return Country
+     */
+    private function makeCountry(array $assoc)
+    {
+        return new Country(
+            $assoc['name'],
+            $assoc['alpha2'],
+            $assoc['alpha3'],
+            $assoc['numeric'],
+            $assoc['currency']
+        );
+    }
+}

--- a/tests/Obj/ISO3166Test.php
+++ b/tests/Obj/ISO3166Test.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace League\ISO3166\Obj;
+
+class ISO3166Test extends \PHPUnit_Framework_TestCase
+{
+    /** @var ISO3166 */
+    private $iso3166;
+
+    /**
+     * Get instance for each test.
+     */
+    public function setUp()
+    {
+        $this->iso3166 = new ISO3166();
+    }
+
+    /**
+     * Sanity check for instantiation.
+     */
+    public function testConstruct()
+    {
+        $this->assertInstanceOf(ISO3166::class, $this->iso3166);
+    }
+
+    /**
+     * Looked up country data should be wrapped in a Country instance.
+     */
+    public function testLookup()
+    {
+        $this->validateCountry($this->iso3166->alpha2('AF'));
+    }
+
+    /**
+     * Country instance should have the right structure.
+     */
+    public function testCountryStructure()
+    {
+        $this->iso3166 = new ISO3166(
+            [
+                [
+                    'name'     => 'Narnia',
+                    'alpha2'   => 'NA',
+                    'alpha3'   => 'NAR',
+                    'numeric'  => '888',
+                    'currency' => [
+                        'GLD',
+                    ],
+                ],
+            ]
+        );
+
+        $narnia = $this->iso3166->alpha2('NA');
+        $this->assertEquals('Narnia', $narnia->name);
+        $this->assertEquals('NA', $narnia->alpha2);
+        $this->assertEquals('NAR', $narnia->alpha3);
+        $this->assertEquals('888', $narnia->numeric);
+        $this->assertEquals('GLD', $narnia->currency[0]);
+    }
+
+    /**
+     * Should be able to get all Country instances.
+     */
+    public function testAll()
+    {
+        $this->validateIteratorCountries($this->iso3166->all());
+    }
+
+    /**
+     * Should be able to get an indexed iterator all countries.
+     */
+    public function testIterator()
+    {
+        $this->validateIteratorCountries($this->iso3166->iterator('alpha2'));
+    }
+
+    /**
+     * Should be able to get an iterator for all countries.
+     */
+    public function testGetIterator()
+    {
+        $this->validateIteratorCountries($this->iso3166->getIterator());
+    }
+
+    /**
+     * @param \Iterator|\Generator|array $countries
+     */
+    private function validateIteratorCountries($countries)
+    {
+        foreach ($countries as $index => $country) {
+            $this->validateCountry($country);
+        }
+    }
+
+    /**
+     * @param Country $country
+     */
+    private function validateCountry(Country $country)
+    {
+        $this->assertInstanceOf(Country::class, $country);
+        $this->assertNotEmpty($country->name);
+        $this->assertNotEmpty($country->alpha2);
+        $this->assertNotEmpty($country->alpha3);
+        $this->assertNotEmpty($country->numeric);
+        $this->assertNotEmpty($country->currency);
+    }
+}


### PR DESCRIPTION
This adds an object-oriented option which gives instances of a `Country` class to complement the existing associative array version. Otherwise it behaves the same.

Some users might prefer this option.
