### PR TITLE
BYR to BYN for Belarus

### DIFF
--- a/src/ISO3166.php
+++ b/src/ISO3166.php
@@ -363,7 +363,7 @@ final class ISO3166 implements \Countable, \IteratorAggregate, ISO3166DataProvid
             'alpha3' => 'BLR',
             'numeric' => '112',
             'currency' => [
-                'BYR',
+                'BYN',
             ],
         ],
         [


### PR DESCRIPTION
Updated Belarus currency according ISO 4217
#35 