### PR TITLE
Adding a common exception interface

### DIFF
--- a/src/Exception/DomainException.php
+++ b/src/Exception/DomainException.php
@@ -9,6 +9,6 @@
 
 namespace League\ISO3166\Exception;
 
-final class DomainException extends \DomainException
+final class DomainException extends \DomainException implements ISO3166Exception
 {
 }

--- a/src/Exception/ISO3166Exception.php
+++ b/src/Exception/ISO3166Exception.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace League\ISO3166\Exception;
+
+interface ISO3166Exception extends \Throwable
+{
+}

--- a/src/Exception/InvalidArgumentException.php
+++ b/src/Exception/InvalidArgumentException.php
@@ -9,6 +9,6 @@
 
 namespace League\ISO3166\Exception;
 
-final class InvalidArgumentException extends \InvalidArgumentException
+final class InvalidArgumentException extends \InvalidArgumentException implements ISO3166Exception
 {
 }

--- a/src/Exception/OutOfBoundsException.php
+++ b/src/Exception/OutOfBoundsException.php
@@ -9,6 +9,6 @@
 
 namespace League\ISO3166\Exception;
 
-final class OutOfBoundsException extends \OutOfBoundsException
+final class OutOfBoundsException extends \OutOfBoundsException implements ISO3166Exception
 {
 }


### PR DESCRIPTION
First of all, thanks for this great library :).

Right now, if I want to check if a country code is valid, I need to do this:

```php
try {
    (new ISO3166())->alpha2($value);

    return true;
} catch (InvalidArgumentException $e) {
} catch (OutOfBoundsException $e) {
} catch (DomainException $e) {
}

return false;
```

or (for PHP ^7.1):

```php
try {
    (new ISO3166())->alpha2($value);

    return true;
} catch (InvalidArgumentException | OutOfBoundsException | DomainException $e) {
    return false;
}
```

This pull request proposes to add a common exception interface for these three exceptions. Therefore I don't have to check first if my `$value` argument is a string that matches 2 chars. If there is an `ISO3166Exception`, and I don't need more details, I know right away that the value I gave leads to nowhere.

New possible behavior (with no BC break):

```php
try {
    (new ISO3166())->alpha2($value);

    return true;
} catch (\League\ISO3166\Exception\ISO3166Exception $e) {
    return false;
}
```