### PR TITLE
Avoid PHP 8.1 deprecations

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         "php": "^7.3|^8.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.0"
+        "phpunit/phpunit": "^9.5"
     },
     "scripts": {
         "cs-review": "php-cs-fixer fix --verbose --diff --dry-run",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -12,16 +12,15 @@
         </testsuite>
     </testsuites>
 
-    <filter>
-        <whitelist>
+    <coverage>
+        <include>
             <directory>src</directory>
-        </whitelist>
-    </filter>
-
-    <logging>
-        <log type="coverage-text" target="php://stderr" />
-        <log type="coverage-html" target="build/coverage" showUncoveredFiles="true"/>
-        <log type="coverage-clover" target="build/coverage.xml" showUncoveredFiles="true"/>
-    </logging>
+        </include>
+        <report>
+            <clover outputFile="build/coverage.xml"/>
+            <html outputDirectory="build/coverage"/>
+            <text outputFile="php://stderr"/>
+        </report>
+    </coverage>
 
 </phpunit>

--- a/src/ISO3166.php
+++ b/src/ISO3166.php
@@ -105,10 +105,8 @@ final class ISO3166 implements \Countable, \IteratorAggregate, ISO3166DataProvid
      * @see \Countable
      *
      * @internal
-     *
-     * @return int
      */
-    public function count()
+    public function count(): int
     {
         return count($this->countries);
     }
@@ -117,10 +115,8 @@ final class ISO3166 implements \Countable, \IteratorAggregate, ISO3166DataProvid
      * @see \IteratorAggregate
      *
      * @internal
-     *
-     * @return \Generator
      */
-    public function getIterator()
+    public function getIterator(): \Generator
     {
         foreach ($this->countries as $country) {
             yield $country;

--- a/tests/ISO3166Test.php
+++ b/tests/ISO3166Test.php
@@ -231,7 +231,7 @@ class ISO3166Test extends TestCase
             }
         } catch (\Exception $e) {
             $this->assertInstanceOf('League\ISO3166\Exception\DomainException', $e);
-            $this->assertRegExp('{Invalid value for \$indexBy, got "\w++", expected one of:(?: \w++,?)+}', $e->getMessage());
+            $this->assertMatchesRegularExpression('{Invalid value for \$indexBy, got "\w++", expected one of:(?: \w++,?)+}', $e->getMessage());
         } finally {
             $this->assertTrue(isset($e));
         }


### PR DESCRIPTION
I've also upgraded to PHPUnit 9.5 and its configuration using `--migrate-configuration` option.

Since the class is `final`, is fine to add the return types to avoid [PHP 8.1 deprecations](https://wiki.php.net/rfc/internal_method_return_types).