### PR TITLE
Added `ReturnTypeWillChange` for php8.1 compatibility

### DIFF
--- a/src/ISO3166.php
+++ b/src/ISO3166.php
@@ -104,6 +104,7 @@ final class ISO3166 implements \Countable, \IteratorAggregate, ISO3166DataProvid
      *
      * @internal
      */
+    #[\ReturnTypeWillChange]
     public function count(): int
     {
         return count($this->countries);
@@ -116,6 +117,7 @@ final class ISO3166 implements \Countable, \IteratorAggregate, ISO3166DataProvid
      *
      * @internal
      */
+    #[\ReturnTypeWillChange]
     public function getIterator(): \Generator
     {
         foreach ($this->countries as $country) {


### PR DESCRIPTION
Hello

can you please check this? It throws deprecation warnings without those (i didnt want to add proper return type as that would break backward compatibility)

Thanks