### PR TITLE
added entry for Canary Islands

### DIFF
--- a/src/ISO3166.php
+++ b/src/ISO3166.php
@@ -1104,6 +1104,15 @@ final class ISO3166 implements \Countable, \IteratorAggregate, ISO3166DataProvid
             ],
         ],
         [
+            'name' => 'Canary Islands',
+            'alpha2' => 'IC',
+            'alpha3' => null,
+            'numeric' => null,
+            'currency' => [
+                'EUR',
+            ],
+        ],
+        [
             'name' => 'Iceland',
             'alpha2' => 'IS',
             'alpha3' => 'ISL',


### PR DESCRIPTION
Signed-off-by: Pascal Paulis <ppaulis@gmail.com>

This PR adds an entry for the Canary Islands:
https://www.iso.org/obp/ui/#iso:code:3166:IC

It seems that they only have an alpha-2 code, but not an alpha-3 or numeric code. I used `null` as a substitute.
Let me know if you consider this problematic.

Thanks!
Best regards,
Pascal