### PR TITLE
Implement exact-match name method for country search

### DIFF
--- a/src/ISO3166.php
+++ b/src/ISO3166.php
@@ -77,6 +77,24 @@ final class ISO3166 implements \Countable, \IteratorAggregate, ISO3166DataProvid
     }
 
     /**
+     * @return array{name: string, alpha2: string, alpha3: string, numeric: numeric-string, currency: string[]}
+     */
+    public function exactName(string $name): array
+    {
+        $value = mb_strtolower($name);
+
+        foreach ($this->countries as $country) {
+            $comparison = mb_strtolower($country[self::KEY_NAME]);
+
+            if ($value === $comparison) {
+                return $country;
+            }
+        }
+
+        throw new OutOfBoundsException(sprintf('No "%s" key found matching: %s', self::KEY_NAME, $value));
+    }
+
+    /**
      * @return array<array{name: string, alpha2: string, alpha3: string, numeric: numeric-string, currency: string[]}>
      */
     public function all(): array

--- a/tests/ISO3166Test.php
+++ b/tests/ISO3166Test.php
@@ -199,6 +199,43 @@ class ISO3166Test extends TestCase
     }
 
     /**
+     * @testdox Calling getByExactName with bad input throws various exceptions.
+     *
+     * @dataProvider invalidExactNameProvider
+     *
+     * @param class-string<\Throwable> $expectedException
+     */
+    public function testGetByExactNameInvalid(string $name, string $expectedException, string $exceptionPattern): void
+    {
+        static::expectException($expectedException);
+        static::expectExceptionMessageMatches($exceptionPattern);
+
+        $this->iso3166->exactName($name);
+    }
+
+    /**
+     * @phpstan-return array<array<string|class-string<\Throwable>|string>>
+     */
+    public function invalidExactNameProvider(): array
+    {
+        $noMatch = sprintf('{^No "%s" key found matching: .*$}', ISO3166::KEY_NAME);
+
+        return [
+            ['FO', OutOfBoundsException::class, $noMatch],
+            ['BA', OutOfBoundsException::class, $noMatch],
+        ];
+    }
+
+    /**
+     * @testdox Calling getByExactName with a known name returns matching data array.
+     */
+    public function testGetByExactName(): void
+    {
+        static::assertEquals($this->foo, $this->iso3166->exactName($this->foo[ISO3166::KEY_NAME]));
+        static::assertEquals($this->bar, $this->iso3166->exactName($this->bar[ISO3166::KEY_NAME]));
+    }
+
+    /**
      * @testdox Calling getAll returns an array with all elements.
      */
     public function testGetAll(): void
@@ -248,7 +285,7 @@ class ISO3166Test extends TestCase
      */
     public function testCountryNameCompare(): void
     {
-        $country = (new ISO3166)->name('CÔTE D\'IVOIRE');
+        $country = (new ISO3166())->name('CÔTE D\'IVOIRE');
 
         static::assertEquals('CIV', $country['alpha3']);
     }


### PR DESCRIPTION
Hello! In #94 , I suggested throwing an exception when multiple country codes were found in a partial match search for country names. However, I received feedback that this might not be the best solution.

So, as a new solution, I've added a name method for exact match search for country names. This method will return the data of a country only if there is a perfect match with the specified country name.

Please review the code below and provide your feedback. Thank you.
