### PR TITLE
Add an alias for The Democratic Republic of the Congo

### DIFF
--- a/src/ISO3166WithAliases.php
+++ b/src/ISO3166WithAliases.php
@@ -30,6 +30,7 @@ class ISO3166WithAliases implements ISO3166DataProvider
             'Bolivia' => 'Bolivia (Plurinational State of)',
             'Bolivia, Plurinational State of' => 'Bolivia (Plurinational State of)',
             'Congo-Kinshasa' => 'Congo (Democratic Republic of the)',
+            'Congo, the Democratic Republic of the' => 'Congo (Democratic Republic of the)',
             'Czech Republic' => 'Czechia',
             'Iran' => 'Iran (Islamic Republic of)',
             'North Korea' => 'Korea (Democratic People\'s Republic of)',

--- a/src/ISO3166WithAliases.php
+++ b/src/ISO3166WithAliases.php
@@ -30,7 +30,7 @@ class ISO3166WithAliases implements ISO3166DataProvider
             'Bolivia' => 'Bolivia (Plurinational State of)',
             'Bolivia, Plurinational State of' => 'Bolivia (Plurinational State of)',
             'Congo-Kinshasa' => 'Congo (Democratic Republic of the)',
-            'Congo, the Democratic Republic of the' => 'Congo (Democratic Republic of the)',
+            'Congo, Democratic Republic of the' => 'Congo (Democratic Republic of the)',
             'Czech Republic' => 'Czechia',
             'Iran' => 'Iran (Islamic Republic of)',
             'North Korea' => 'Korea (Democratic People\'s Republic of)',


### PR DESCRIPTION
Add country as shown in Wikipedia
![2023-08-28_105637](https://github.com/thephpleague/iso3166/assets/13252042/9110b68e-dd1a-412c-910e-dc39d6a004d4)
