### PR TITLE
feat: Ensure that data entries are strings

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,21 +1,6 @@
 parameters:
 	ignoreErrors:
 		-
-			message: "#^Parameter \\#1 \\$alpha2 of static method League\\\\ISO3166\\\\Guards\\:\\:guardAgainstInvalidAlpha2\\(\\) expects string, mixed given\\.$#"
-			count: 1
-			path: src/ISO3166DataValidator.php
-
-		-
-			message: "#^Parameter \\#1 \\$alpha3 of static method League\\\\ISO3166\\\\Guards\\:\\:guardAgainstInvalidAlpha3\\(\\) expects string, mixed given\\.$#"
-			count: 1
-			path: src/ISO3166DataValidator.php
-
-		-
-			message: "#^Parameter \\#1 \\$numeric of static method League\\\\ISO3166\\\\Guards\\:\\:guardAgainstInvalidNumeric\\(\\) expects string, mixed given\\.$#"
-			count: 1
-			path: src/ISO3166DataValidator.php
-
-		-
 			message: "#^Parameter \\#1 \\$countries of class League\\\\ISO3166\\\\ISO3166 constructor expects array\\<array\\{name\\: string, alpha2\\: string, alpha3\\: string, numeric\\: numeric\\-string, currency\\: array\\<string\\>\\}\\>, array\\<array\\<string, mixed\\>\\> given\\.$#"
 			count: 1
 			path: tests/ISO3166Test.php

--- a/src/ISO3166.php
+++ b/src/ISO3166.php
@@ -26,7 +26,7 @@ final class ISO3166 implements \Countable, \IteratorAggregate, ISO3166DataProvid
     /** @var string */
     public const KEY_NAME = 'name';
     /** @var string[] */
-    private array $keys = [self::KEY_ALPHA2, self::KEY_ALPHA3, self::KEY_NUMERIC, self::KEY_NAME];
+    private const KEYS = [self::KEY_ALPHA2, self::KEY_ALPHA3, self::KEY_NUMERIC, self::KEY_NAME];
 
     /**
      * @param array<array{name: string, alpha2: string, alpha3: string, numeric: numeric-string, currency: string[]}> $countries replace default dataset with given array
@@ -36,6 +36,14 @@ final class ISO3166 implements \Countable, \IteratorAggregate, ISO3166DataProvid
         if ([] !== $countries) {
             $this->countries = $countries;
         }
+    }
+
+    /**
+     * @return string[]
+     */
+    public static function getKeys(): array
+    {
+        return self::KEYS;
     }
 
     /**
@@ -115,8 +123,8 @@ final class ISO3166 implements \Countable, \IteratorAggregate, ISO3166DataProvid
      */
     public function iterator(string $key = self::KEY_ALPHA2): \Generator
     {
-        if (!in_array($key, $this->keys, true)) {
-            throw new DomainException(sprintf('Invalid value for $key, got "%s", expected one of: %s', $key, implode(', ', $this->keys)));
+        if (!in_array($key, self::getKeys(), true)) {
+            throw new DomainException(sprintf('Invalid value for $key, got "%s", expected one of: %s', $key, implode(', ', self::getKeys())));
         }
 
         foreach ($this->countries as $country) {

--- a/src/ISO3166.php
+++ b/src/ISO3166.php
@@ -26,7 +26,7 @@ final class ISO3166 implements \Countable, \IteratorAggregate, ISO3166DataProvid
     /** @var string */
     public const KEY_NAME = 'name';
     /** @var string[] */
-    private const KEYS = [self::KEY_ALPHA2, self::KEY_ALPHA3, self::KEY_NUMERIC, self::KEY_NAME];
+    private array $keys = [self::KEY_ALPHA2, self::KEY_ALPHA3, self::KEY_NUMERIC, self::KEY_NAME];
 
     /**
      * @param array<array{name: string, alpha2: string, alpha3: string, numeric: numeric-string, currency: string[]}> $countries replace default dataset with given array
@@ -36,14 +36,6 @@ final class ISO3166 implements \Countable, \IteratorAggregate, ISO3166DataProvid
         if ([] !== $countries) {
             $this->countries = $countries;
         }
-    }
-
-    /**
-     * @return string[]
-     */
-    public static function getKeys(): array
-    {
-        return self::KEYS;
     }
 
     /**
@@ -123,8 +115,8 @@ final class ISO3166 implements \Countable, \IteratorAggregate, ISO3166DataProvid
      */
     public function iterator(string $key = self::KEY_ALPHA2): \Generator
     {
-        if (!in_array($key, self::getKeys(), true)) {
-            throw new DomainException(sprintf('Invalid value for $key, got "%s", expected one of: %s', $key, implode(', ', self::getKeys())));
+        if (!in_array($key, $this->keys, true)) {
+            throw new DomainException(sprintf('Invalid value for $key, got "%s", expected one of: %s', $key, implode(', ', $this->keys)));
         }
 
         foreach ($this->countries as $country) {

--- a/src/ISO3166DataValidator.php
+++ b/src/ISO3166DataValidator.php
@@ -36,19 +36,44 @@ final class ISO3166DataValidator
      */
     private function assertEntryHasRequiredKeys(array $entry): void
     {
-        foreach (ISO3166::getKeys() as $key) {
-            if (false === isset($entry[$key])) {
-                throw new DomainException("Each data entry must have a $key key.");
-            }
+        if (!isset($entry[ISO3166::KEY_NAME])) {
+            throw new DomainException('Each data entry must have a name key.');
+        }
 
-            if (false === is_string($entry[$key])) {
-                throw new DomainException("Property $key of all data entries must be a string.");
-            }
+        if (false === is_string($entry[ISO3166::KEY_NAME])) {
+            throw new DomainException('Property '.ISO3166::KEY_NAME.' of all data entries must be a string.');
         }
 
         Guards::guardAgainstInvalidName($entry[ISO3166::KEY_NAME]);
+
+        if (!isset($entry[ISO3166::KEY_ALPHA2])) {
+            throw new DomainException('Each data entry must have a alpha2 key.');
+        }
+
+        if (false === is_string($entry[ISO3166::KEY_ALPHA2])) {
+            throw new DomainException('Property '.ISO3166::KEY_ALPHA2.' of all data entries must be a string.');
+        }
+
         Guards::guardAgainstInvalidAlpha2($entry[ISO3166::KEY_ALPHA2]);
+
+        if (!isset($entry[ISO3166::KEY_ALPHA3])) {
+            throw new DomainException('Each data entry must have a alpha3 key.');
+        }
+
+        if (false === is_string($entry[ISO3166::KEY_ALPHA3])) {
+            throw new DomainException('Property '.ISO3166::KEY_ALPHA3.' of all data entries must be a string.');
+        }
+
         Guards::guardAgainstInvalidAlpha3($entry[ISO3166::KEY_ALPHA3]);
+
+        if (!isset($entry[ISO3166::KEY_NUMERIC])) {
+            throw new DomainException('Each data entry must have a numeric key.');
+        }
+
+        if (false === is_string($entry[ISO3166::KEY_NUMERIC])) {
+            throw new DomainException('Property '.ISO3166::KEY_NUMERIC.' of all data entries must be a string.');
+        }
+
         Guards::guardAgainstInvalidNumeric($entry[ISO3166::KEY_NUMERIC]);
     }
 }

--- a/src/ISO3166DataValidator.php
+++ b/src/ISO3166DataValidator.php
@@ -36,28 +36,19 @@ final class ISO3166DataValidator
      */
     private function assertEntryHasRequiredKeys(array $entry): void
     {
-        if (!isset($entry[ISO3166::KEY_NAME])) {
-            throw new DomainException('Each data entry must have a name key.');
+        foreach (ISO3166::getKeys() as $key) {
+            if (false === isset($entry[$key])) {
+                throw new DomainException("Each data entry must have a $key key.");
+            }
+
+            if (false === is_string($entry[$key])) {
+                throw new DomainException("Property $key of all data entries must be a string.");
+            }
         }
 
         Guards::guardAgainstInvalidName($entry[ISO3166::KEY_NAME]);
-
-        if (!isset($entry[ISO3166::KEY_ALPHA2])) {
-            throw new DomainException('Each data entry must have a alpha2 key.');
-        }
-
         Guards::guardAgainstInvalidAlpha2($entry[ISO3166::KEY_ALPHA2]);
-
-        if (!isset($entry[ISO3166::KEY_ALPHA3])) {
-            throw new DomainException('Each data entry must have a alpha3 key.');
-        }
-
         Guards::guardAgainstInvalidAlpha3($entry[ISO3166::KEY_ALPHA3]);
-
-        if (!isset($entry[ISO3166::KEY_NUMERIC])) {
-            throw new DomainException('Each data entry must have a numeric key.');
-        }
-
         Guards::guardAgainstInvalidNumeric($entry[ISO3166::KEY_NUMERIC]);
     }
 }


### PR DESCRIPTION
This PR fixes the following PHPStan error:  
https://github.com/alcohol/iso3166/actions/runs/18493883166/job/52697805520?pr=119

By checking that the data entry is correct before applying the validators,   
We can delete some errors in the PHPStan baseline.  