### PR TITLE
Update Bulgaria currency: from BGN to EUR since 01/01/2026

### DIFF
--- a/src/ISO3166.php
+++ b/src/ISO3166.php
@@ -275,7 +275,6 @@ final class ISO3166 implements \Countable, \IteratorAggregate, ISO3166DataProvid
             'currency' => [
                 'ARS',
                 'AUD',
-                'BGN',
                 'BRL',
                 'BYR',
                 'CLP',
@@ -532,7 +531,7 @@ final class ISO3166 implements \Countable, \IteratorAggregate, ISO3166DataProvid
             'alpha3' => 'BGR',
             'numeric' => '100',
             'currency' => [
-                'BGN',
+                'EUR',
             ],
         ],
         [


### PR DESCRIPTION
Bulgaria adopted the euro yesterday, January 1, 2026. 
As a result, the Bulgarian lev has been replaced by the single currency of the eurozone.

[See more](https://www.ecb.europa.eu/euro/changeover/bulgaria/html/index.en.html)